### PR TITLE
Save check-in chat responses

### DIFF
--- a/app/api/checkin/route.ts
+++ b/app/api/checkin/route.ts
@@ -129,7 +129,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const { checkinId, response } = await request.json()
+    const { checkinId, response, sessionId } = await request.json()
     
     const supabase = createServerClient()
     const { data: { user }, error: authError } = await supabase.auth.getUser()
@@ -138,13 +138,18 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // Update the check-in with response
+    // Update the check-in with response and session reference
+    const updateData: Record<string, any> = {
+      response: response,
+      completed: true,
+    }
+    if (sessionId) {
+      updateData.session_id = sessionId
+    }
+
     const { data, error } = await supabase
       .from('daily_checkins')
-      .update({
-        response: response,
-        completed: true,
-      })
+      .update(updateData)
       .eq('id', checkinId)
       .eq('user_id', user.id) // Ensure user owns this check-in
       .select()

--- a/app/dashboard/checkins/page.tsx
+++ b/app/dashboard/checkins/page.tsx
@@ -11,6 +11,7 @@ interface DailyCheckin {
   response: string | null
   completed: boolean
   created_at: string
+  session_id: string | null
 }
 
 export default function CheckinsPage() {

--- a/components/dashboard/daily-checkin-widget.tsx
+++ b/components/dashboard/daily-checkin-widget.tsx
@@ -11,6 +11,7 @@ interface DailyCheckin {
   response: string | null | undefined
   completed: boolean
   created_at: string
+  session_id: string | null | undefined
 }
 
 export function DailyCheckinWidget() {
@@ -21,6 +22,9 @@ export function DailyCheckinWidget() {
 
   useEffect(() => {
     fetchTodaysCheckin()
+    const handleFocus = () => fetchTodaysCheckin()
+    window.addEventListener('focus', handleFocus)
+    return () => window.removeEventListener('focus', handleFocus)
   }, [])
 
   const fetchTodaysCheckin = async () => {

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -69,9 +69,11 @@ CREATE TABLE public.daily_checkins (
   prompt text NOT NULL,
   response text,
   completed boolean DEFAULT false,
+  session_id uuid,
   created_at timestamp with time zone DEFAULT now(),
   CONSTRAINT daily_checkins_pkey PRIMARY KEY (id),
-  CONSTRAINT daily_checkins_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id)
+  CONSTRAINT daily_checkins_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id),
+  CONSTRAINT daily_checkins_session_id_fkey FOREIGN KEY (session_id) REFERENCES public.chat_sessions(id)
 );
 CREATE TABLE public.grimoire_entries (
   id uuid NOT NULL DEFAULT uuid_generate_v4(),

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -154,6 +154,7 @@ export interface Database {
           prompt: string
           response: string | null
           completed: boolean
+          session_id: string | null
           created_at: string
         }
         Insert: {
@@ -162,6 +163,7 @@ export interface Database {
           prompt: string
           response?: string | null
           completed?: boolean
+          session_id?: string | null
           created_at?: string
         }
         Update: {
@@ -170,6 +172,7 @@ export interface Database {
           prompt?: string
           response?: string | null
           completed?: boolean
+          session_id?: string | null
           created_at?: string
         }
       }


### PR DESCRIPTION
## **User description**
## Summary
- save a check-in response once the first user message is sent in a check-in chat session
- track the chat session on check-in records and API
- refresh dashboard check-in widget after a response is stored

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68902dc7dc008321aa1fd3cc64b78aec


___

## **CodeAnt-AI Description**
- Added `session_id` column to `daily_checkins` in the Supabase schema and updated the corresponding TypeScript types (`Database.daily_checkins` interfaces) to include `session_id` in `Row`, `Insert`, and `Update` definitions.
- Enhanced the POST `/api/checkin` endpoint to accept a `sessionId` parameter and update the `session_id` field in `daily_checkins` when provided.
- Implemented frontend logic in the chat page to capture the first user message, automatically send it to the check-in API with `checkinId` and `sessionId`, and prevent duplicate saves using a `checkinSaved` flag.
- Updated daily check-in widget to refresh on window focus and handle the new `session_id` field within the `DailyCheckin` interface for consistent state updates.

This PR improves the check-in workflow by linking chat sessions to daily check-ins, ensuring that users’ first responses are automatically saved and that the UI reflects the latest record with session context.
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily check-ins can now be optionally linked to chat sessions, providing better integration between check-ins and chat activity.

* **Improvements**
  * Check-in data automatically refreshes when the dashboard window regains focus, ensuring up-to-date information.
  * User responses to daily check-in prompts in chat are now saved and associated with the relevant session for improved tracking.

* **Database Updates**
  * Added a new field to daily check-ins to store an optional session reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->